### PR TITLE
Attempt to avoid PRs before stability days elapsed

### DIFF
--- a/default.json
+++ b/default.json
@@ -73,5 +73,6 @@
   "schedule": ["before 6am", "every weekend"],
   "semanticCommits": true,
   "stabilityDays": 3,
+  "prNotPendingHours": 74,
   "timezone": "Europe/Oslo"
 }


### PR DESCRIPTION
Set prNotPendingHours to 3 days and 2 hours so it is higher than
the stabilityDays value.