### PR TITLE
Group junit5 packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -65,6 +65,14 @@
         "^software.amazon.awssdk:"
       ],
       "groupName": "aws-sdk-java-v2 monorepo"
+    },
+    {
+      "packagePatterns": [
+        "^org.junit.jupiter:",
+        "^org.junit.platform:",
+        "^org.junit.vintage:"
+      ],
+      "groupName": "junit5 packages"
     }
   ],
   "pin": {


### PR DESCRIPTION
It seems these packages are versioned together. See https://search.maven.org/artifact/org.junit/junit-bom/5.6.0/pom and https://junit.org/junit5/docs/current/user-guide/#dependency-metadata

This will make these PRs and alike be grouped into one update:
https://github.com/capraconsulting/siren-util/pull/11
https://github.com/capraconsulting/siren-util/pull/12
https://github.com/capraconsulting/siren-util/pull/13