### PR TITLE
Don't close master issue

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,7 +7,6 @@
     "automerge": false
   },
   "masterIssue": true,
-  "masterIssueAutoclose": true,
   "packageRules": [
     {
       "packageNames": [


### PR DESCRIPTION
Føler det er litt plagsomt med GitHub notifications på issues som åpnes/lukkes på grunn av det dukker opp en oppdatering som litt senere auto-merges. Så foreslår disse master issuene bare kan forbli åpne.